### PR TITLE
build: configure docs.rs and relax feature requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "sha2_hasher"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const-hex",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ tokio = { version = "1.49", features = ["fs", "macros", "rt"] }
 default = []
 async = ["dep:tokio"]
 sync = []
+
+[package.metadata.docs.rs]
+features = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2_hasher"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["kaoru <k@warpnine.io>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@ compile_error!(
     "Features `async` and `sync` are mutually exclusive. Please enable only one of them."
 );
 
-#[cfg(not(any(feature = "async", feature = "sync")))]
-compile_error!("Either `async` or `sync` feature must be enabled.");
-
 #[cfg(feature = "async")]
 mod r#async;
 #[cfg(feature = "async")]


### PR DESCRIPTION
Configure docs.rs to build with the async feature enabled, and remove
the compile-time requirement to enable either async or sync feature.
This allows more flexible feature configuration for users.